### PR TITLE
fix/proxy remote url can change

### DIFF
--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -5,6 +5,7 @@ import time
 from concurrent.futures import Future
 from pathlib import Path
 from typing import Optional, Union
+from urllib.parse import urlparse
 
 from mopidy import backend
 from pykka import ThreadingActor
@@ -60,7 +61,11 @@ class TidalBackend(ThreadingActor, backend.Backend):
     def playback_cache_for(self, uri: str) -> ThreadedProxy | None:
         def cache():
             if self._tidal_config["playback_cache"]:
+                track_url = self.session.track(uri.split(":")[-1]).get_url()
+                parsed = urlparse(track_url)
+
                 return mopidy_playback_cache(
+                    f"{parsed.scheme}://{parsed.netloc}",
                     Path(Extension.get_cache_dir(self._config)) / "playback.db",
                     self._tidal_config["playback_cache_max_entries"],
                     self._tidal_config["playback_cache_buffer_bytes"],

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -42,6 +42,8 @@ class TidalBackend(ThreadingActor, backend.Backend):
         self.session_file_path: Path = Path("")
         self.web_auth_server: WebAuthServer = WebAuthServer()
 
+        self._playback_cache: Lazy[ThreadedProxy | None] = Lazy()
+
         # Config parameters
         # Lazy: Connect lazily, i.e. login only when user starts browsing TIDAL directories
         self.lazy_connect: bool = False
@@ -55,17 +57,18 @@ class TidalBackend(ThreadingActor, backend.Backend):
         # login_server_port: Port to use for login HTTP server, eg. <host_ip>:<port>. Default <host_ip>:8989
         self.login_server_port: int = 8989
 
-    @property
-    def playback_cache(self) -> ThreadedProxy | None:
-        if self._tidal_config["playback_cache"]:
-            path = Path(Extension.get_cache_dir(self._config)) / "playback.db"
-            return mopidy_playback_cache(
-                path,
-                self._tidal_config["playback_cache_max_entries"],
-                self._tidal_config["playback_cache_buffer_bytes"],
-            )
-        else:
-            return None
+    def playback_cache_for(self, uri: str) -> ThreadedProxy | None:
+        def cache():
+            if self._tidal_config["playback_cache"]:
+                return mopidy_playback_cache(
+                    Path(Extension.get_cache_dir(self._config)) / "playback.db",
+                    self._tidal_config["playback_cache_max_entries"],
+                    self._tidal_config["playback_cache_buffer_bytes"],
+                )
+            else:
+                return None
+
+        return self._playback_cache.get_or(cache)
 
     @property
     def session(self):
@@ -245,5 +248,5 @@ class TidalBackend(ThreadingActor, backend.Backend):
             return f"{self._login_url}" if self._login_url else None
 
     def on_stop(self) -> None:
-        if cache := self.playback_cache:
+        if cache := self._playback_cache.get_or_none():
             cache.stop()

--- a/mopidy_tidal/gstreamer_proxy/__init__.py
+++ b/mopidy_tidal/gstreamer_proxy/__init__.py
@@ -8,16 +8,14 @@ from .proxy import Proxy, ProxyConfig, ThreadedProxy
 
 @functools.cache
 def mopidy_playback_cache(
+    remote_url: str,
     path: Path,
     buffer_bytes: int,
     max_entries: int | None,
 ) -> ThreadedProxy:
     path.parent.mkdir(parents=True, exist_ok=True)
     proxy = Proxy(
-        ProxyConfig.build(
-            None,
-            "https://lgf.audio.tidal.com/",
-        ),
+        ProxyConfig.build(None, remote_url),
         lambda: SQLiteCache(sqlite3.connect(path), max_entries=max_entries),
         buffer_bytes=buffer_bytes,
     )

--- a/mopidy_tidal/playback.py
+++ b/mopidy_tidal/playback.py
@@ -90,7 +90,7 @@ class TidalPlaybackProvider(backend.PlaybackProvider):
     def translate_uri(self, uri) -> str:
         logger.info("TIDAL uri: %s", uri)
 
-        if proxy := self.backend.playback_cache:
+        if proxy := self.backend.playback_cache_for(uri):
             id = cache.TidalID(uri)
             if entry := proxy.cache.lookup_entry(id):
                 return proxy.config.local_url(entry.path.decode())

--- a/mopidy_tidal/types.py
+++ b/mopidy_tidal/types.py
@@ -1,15 +1,18 @@
 from dataclasses import dataclass
+from enum import Enum
 from typing import Callable
+
+_UNSET = Enum("_UNSET", "_UNSET")
 
 
 @dataclass
 class Lazy[T]:
     """Type-safe T | None for lazy attributes."""
 
-    inner: T | None = None
+    inner: T | _UNSET = _UNSET._UNSET
 
     def get(self) -> T:
-        if self.inner is None:
+        if self.inner is _UNSET._UNSET:
             raise ValueError("Lazy value not set")
         else:
             return self.inner
@@ -18,9 +21,12 @@ class Lazy[T]:
         self.inner = val
 
     def get_or(self, init: Callable[[], T]) -> T:
-        if self.inner is None:
+        if self.inner is _UNSET._UNSET:
             self.set(init())
         return self.get()
 
     def get_or_none(self) -> T | None:
-        return self.inner
+        if self.inner is _UNSET._UNSET:
+            return None
+        else:
+            return self.inner

--- a/mopidy_tidal/types.py
+++ b/mopidy_tidal/types.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class Lazy[T]:
+    """Type-safe T | None for lazy attributes."""
+
+    inner: T | None = None
+
+    def get(self) -> T:
+        if self.inner is None:
+            raise ValueError("Lazy value not set")
+        else:
+            return self.inner
+
+    def set(self, val: T) -> None:
+        self.inner = val
+
+    def get_or(self, init: Callable[[], T]) -> T:
+        if self.inner is None:
+            self.set(init())
+        return self.get()
+
+    def get_or_none(self) -> T | None:
+        return self.inner

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,33 @@
+import pytest
+
+from mopidy_tidal import types
+
+
+class TestLazy:
+    def test_raises_if_not_set(self):
+        with pytest.raises(ValueError):
+            types.Lazy().get()
+
+    def test_value_retrievable_after_setting(self):
+        lazy = types.Lazy()
+
+        lazy.set(123)
+
+        assert lazy.get() == lazy.get() == 123
+
+    def test_callback_used_when_value_missing(self):
+        called = 0
+
+        def init() -> int:
+            nonlocal called
+            called += 1
+            return 123
+
+        lazy = types.Lazy()
+
+        assert lazy.get_or(init) == 123
+        assert lazy.get_or(init) == 123
+        assert called == 1
+
+    def test_get_or_none_elides_inner_optionals(self):
+        assert types.Lazy(inner=None).get_or_none() is None

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -31,3 +31,6 @@ class TestLazy:
 
     def test_get_or_none_elides_inner_optionals(self):
         assert types.Lazy(inner=None).get_or_none() is None
+
+    def test_get_or_can_store_none(self):
+        assert types.Lazy().get_or(lambda: None) is None


### PR DESCRIPTION
When I wrote the proxy, I assumed tidal's upstream URL would stay fixed.  Here on holiday in Milan, it's changed.  I don't know if that's regional or not, but it makes sense to look it up.

I've assumed that all tracks will have the same proxy url within a session.  This could still fail if:

- you take a long running mopidy session over a national border (if it's regional)
- different tracks have different remote proxy urls

In which case let's open an issue and fix it when it comes in.

The `Lazy[T]` proxy class is my current favourite way to get a typesafe `| None`.
