### PR TITLE
refactor/type safe session

### DIFF
--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -15,6 +15,7 @@ from tidalapi import __version__ as tidalapi_ver
 from mopidy_tidal import Extension, context, library, playback, playlists
 from mopidy_tidal import __version__ as mopidy_tidal_ver
 from mopidy_tidal.gstreamer_proxy import ThreadedProxy, mopidy_playback_cache
+from mopidy_tidal.types import Lazy
 from mopidy_tidal.web_auth_server import WebAuthServer
 
 logger = logging.getLogger(__name__)
@@ -34,7 +35,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
         self.playlists = playlists.TidalPlaylistsProvider(backend=self)
 
         # Session parameters
-        self._active_session: Optional[Session] = None
+        self._active_session: Lazy[Session] = Lazy()
         self._logged_in: bool = False
         self.uri_schemes: tuple[str] = ("tidal",)
         self._login_future: Optional[Future] = None
@@ -76,23 +77,25 @@ class TidalBackend(ThreadingActor, backend.Backend):
         return self._playback_cache.get_or(cache)
 
     @property
-    def session(self):
+    def session(self) -> Session:
         if not self.logged_in:
             self._login()
-        return self._active_session
+        return self._active_session.get()
 
     @property
-    def logged_in(self):
+    def logged_in(self) -> bool:
         if not self._logged_in:
-            if self._active_session.load_session_from_file(self.session_file_path):
+            if self._active_session.get().load_session_from_file(
+                self.session_file_path
+            ):
                 logger.info("Loaded TIDAL session from file %s", self.session_file_path)
                 self._logged_in = self.session_valid
         return self._logged_in
 
     @property
-    def session_valid(self):
+    def session_valid(self) -> bool:
         # Returns true when session is logged in and valid
-        return self._active_session.check_login()
+        return self._active_session.get().check_login()
 
     def on_start(self):
         logger.info("Mopidy-Tidal version: v%s", mopidy_tidal_ver)
@@ -137,13 +140,13 @@ class TidalBackend(ThreadingActor, backend.Backend):
         else:
             logger.info("Using default client id & client secret from python-tidal")
 
-        self._active_session = Session(config)
+        self._active_session.set(Session(config))
         if not self.lazy_connect:
             self._login()
 
     def _login(self):
         """Load session at startup or create a new session"""
-        if self._active_session.load_session_from_file(self.session_file_path):
+        if self._active_session.get().load_session_from_file(self.session_file_path):
             logger.info(
                 "Loaded existing TIDAL session from file %s...", self.session_file_path
             )
@@ -151,7 +154,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
             if not self.login_server_port:
                 # A. Default login, user must find login URL in Mopidy log
                 logger.info("Creating new session (OAuth)...")
-                self._active_session.login_oauth_simple(fn_print=logger.info)
+                self._active_session.get().login_oauth_simple(fn_print=logger.info)
             else:
                 # B. Interactive login, user must perform login using web auth
                 logger.info(
@@ -160,7 +163,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
                 )
                 if self.pkce_enabled:
                     # PKCE Login
-                    login_url = self._active_session.pkce_login_url()
+                    login_url = self._active_session.get().pkce_login_url()
                     logger.info(
                         "Please visit 'http://localhost:%s' to authenticate",
                         self.login_server_port,
@@ -173,6 +176,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
                 else:
                     # OAuth login
                     login_url = self.login_url
+                    assert login_url
                     logger.info(
                         "Please visit 'http://localhost:%s' or '%s' to authenticate",
                         self.login_server_port,
@@ -206,10 +210,10 @@ class TidalBackend(ThreadingActor, backend.Backend):
             try:
                 # Query for auth tokens
                 json: dict[str, Union[str, int]] = (
-                    self._active_session.pkce_get_auth_token(url_redirect)
+                    self._active_session.get().pkce_get_auth_token(url_redirect)
                 )
                 # Parse and set tokens.
-                self._active_session.process_auth_token(json, is_pkce_token=True)
+                self._active_session.get().process_auth_token(json, is_pkce_token=True)
                 self._logged_in = True
             except Exception:
                 raise ValueError("Response code is required for PKCE login!")
@@ -221,7 +225,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
         if self.session_valid:
             # Only store current session if valid
             logger.info("TIDAL Login OK")
-            self._active_session.save_session_to_file(self.session_file_path)
+            self._active_session.get().save_session_to_file(self.session_file_path)
             self._logged_in = True
         else:
             logger.error("TIDAL Login Failed")
@@ -237,13 +241,13 @@ class TidalBackend(ThreadingActor, backend.Backend):
         """Start a new login sequence (if not active) and get the latest login URL"""
         if not self.pkce_enabled:
             if not self._logged_in and not self.logging_in:
-                login_url, self._login_future = self._active_session.login_oauth()
+                login_url, self._login_future = self._active_session.get().login_oauth()
                 self._login_future.add_done_callback(lambda *_: self._complete_login())
                 self._login_url = login_url.verification_uri_complete
             return f"https://{self._login_url}" if self._login_url else None
         else:
             if not self._logged_in and not self.web_auth_server.is_daemon_running:
-                login_url = self._active_session.pkce_login_url()
+                login_url = self._active_session.get().pkce_login_url()
                 self._login_url = "http://localhost:{}".format(self.login_server_port)
                 # Enable web server for interactive login + callback on form Submit
                 self.web_auth_server.set_callback(self._web_auth_callback)

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -5,6 +5,7 @@ import time
 from concurrent.futures import Future
 from pathlib import Path
 from typing import Optional, Union
+from urllib.parse import urlparse
 
 from mopidy import backend
 from pykka import ThreadingActor
@@ -60,7 +61,11 @@ class TidalBackend(ThreadingActor, backend.Backend):
     def playback_cache_for(self, uri: str) -> ThreadedProxy | None:
         def cache():
             if self._tidal_config["playback_cache"]:
+                track_url = self.session.track(uri.split(":")[-1]).get_url()
+                parsed = urlparse(track_url)
+
                 return mopidy_playback_cache(
+                    f"{parsed.scheme}://{parsed.netloc}",
                     Path(Extension.get_cache_dir(self._config)) / "playback.db",
                     self._tidal_config["playback_cache_max_entries"],
                     self._tidal_config["playback_cache_buffer_bytes"],

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -42,6 +42,8 @@ class TidalBackend(ThreadingActor, backend.Backend):
         self.session_file_path: Path = Path("")
         self.web_auth_server: WebAuthServer = WebAuthServer()
 
+        self._playback_cache: Lazy[ThreadedProxy | None] = Lazy()
+
         # Config parameters
         # Lazy: Connect lazily, i.e. login only when user starts browsing TIDAL directories
         self.lazy_connect: bool = False
@@ -55,17 +57,18 @@ class TidalBackend(ThreadingActor, backend.Backend):
         # login_server_port: Port to use for login HTTP server, eg. <host_ip>:<port>. Default <host_ip>:8989
         self.login_server_port: int = 8989
 
-    @property
-    def playback_cache(self) -> ThreadedProxy | None:
-        if self._tidal_config["playback_cache"]:
-            path = Path(Extension.get_cache_dir(self._config)) / "playback.db"
-            return mopidy_playback_cache(
-                path,
-                self._tidal_config["playback_cache_max_entries"],
-                self._tidal_config["playback_cache_buffer_bytes"],
-            )
-        else:
-            return None
+    def playback_cache_for(self, uri: str) -> ThreadedProxy | None:
+        def cache():
+            if self._tidal_config["playback_cache"]:
+                return mopidy_playback_cache(
+                    Path(Extension.get_cache_dir(self._config)) / "playback.db",
+                    self._tidal_config["playback_cache_max_entries"],
+                    self._tidal_config["playback_cache_buffer_bytes"],
+                )
+            else:
+                return None
+
+        return self._playback_cache.get_or(cache)
 
     @property
     def session(self):
@@ -245,5 +248,5 @@ class TidalBackend(ThreadingActor, backend.Backend):
             return f"{self._login_url}" if self._login_url else None
 
     def on_stop(self) -> None:
-        if cache := self.playback_cache:
+        if cache := self._playback_cache.get_or_none():
             cache.stop()

--- a/mopidy_tidal/gstreamer_proxy/__init__.py
+++ b/mopidy_tidal/gstreamer_proxy/__init__.py
@@ -8,16 +8,14 @@ from .proxy import Proxy, ProxyConfig, ThreadedProxy
 
 @functools.cache
 def mopidy_playback_cache(
+    remote_url: str,
     path: Path,
     buffer_bytes: int,
     max_entries: int | None,
 ) -> ThreadedProxy:
     path.parent.mkdir(parents=True, exist_ok=True)
     proxy = Proxy(
-        ProxyConfig.build(
-            None,
-            "https://lgf.audio.tidal.com/",
-        ),
+        ProxyConfig.build(None, remote_url),
         lambda: SQLiteCache(sqlite3.connect(path), max_entries=max_entries),
         buffer_bytes=buffer_bytes,
     )

--- a/mopidy_tidal/playback.py
+++ b/mopidy_tidal/playback.py
@@ -90,7 +90,7 @@ class TidalPlaybackProvider(backend.PlaybackProvider):
     def translate_uri(self, uri) -> str:
         logger.info("TIDAL uri: %s", uri)
 
-        if proxy := self.backend.playback_cache:
+        if proxy := self.backend.playback_cache_for(uri):
             id = cache.TidalID(uri)
             if entry := proxy.cache.lookup_entry(id):
                 return proxy.config.local_url(entry.path.decode())

--- a/mopidy_tidal/types.py
+++ b/mopidy_tidal/types.py
@@ -1,15 +1,18 @@
 from dataclasses import dataclass
+from enum import Enum
 from typing import Callable
+
+_UNSET = Enum("_UNSET", "_UNSET")
 
 
 @dataclass
 class Lazy[T]:
     """Type-safe T | None for lazy attributes."""
 
-    inner: T | None = None
+    inner: T | _UNSET = _UNSET._UNSET
 
     def get(self) -> T:
-        if self.inner is None:
+        if self.inner is _UNSET._UNSET:
             raise ValueError("Lazy value not set")
         else:
             return self.inner
@@ -18,9 +21,12 @@ class Lazy[T]:
         self.inner = val
 
     def get_or(self, init: Callable[[], T]) -> T:
-        if self.inner is None:
+        if self.inner is _UNSET._UNSET:
             self.set(init())
         return self.get()
 
     def get_or_none(self) -> T | None:
-        return self.inner
+        if self.inner is _UNSET._UNSET:
+            return None
+        else:
+            return self.inner

--- a/mopidy_tidal/types.py
+++ b/mopidy_tidal/types.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class Lazy[T]:
+    """Type-safe T | None for lazy attributes."""
+
+    inner: T | None = None
+
+    def get(self) -> T:
+        if self.inner is None:
+            raise ValueError("Lazy value not set")
+        else:
+            return self.inner
+
+    def set(self, val: T) -> None:
+        self.inner = val
+
+    def get_or(self, init: Callable[[], T]) -> T:
+        if self.inner is None:
+            self.set(init())
+        return self.get()
+
+    def get_or_none(self) -> T | None:
+        return self.inner

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -22,7 +22,8 @@ def test_backend_begins_in_correct_state(get_backend):
     backend, config, *_ = get_backend()
 
     assert backend.uri_schemes == ("tidal",)
-    assert not backend._active_session
+    with pytest.raises(ValueError):
+        backend._active_session.get()
     assert backend._config is config
 
 
@@ -36,7 +37,7 @@ def test_initial_login_caches_credentials(get_backend, config):
     # Starting the mock web server will trigger login instantly
     backend.web_auth_server.start_oauth_daemon.side_effect = login_success
 
-    backend._active_session = session
+    backend._active_session.set(session)
     authf = Path(config["core"]["data_dir"], "tidal/tidal-oauth.json")
     assert not authf.exists()
 
@@ -74,7 +75,7 @@ def test_login_after_failed_cached_credentials_overwrites_cached_credentials(
     # Starting the mock web server will trigger login instantly
     backend.web_auth_server.start_oauth_daemon.side_effect = login_success
 
-    backend._active_session = session
+    backend._active_session.set(session)
     authf = Path(config["core"]["data_dir"], "tidal/tidal-oauth.json")
     cached_data = {
         "token_type": dict(data="token_type2"),
@@ -114,7 +115,7 @@ def test_failed_login_does_not_overwrite_cached_credentials(
     # Starting the mock web server will trigger login instantly (but login will fail)
     backend.web_auth_server.start_oauth_daemon.side_effect = login_failed
 
-    backend._active_session = session
+    backend._active_session.set(session)
     authf = Path(config["core"]["data_dir"], "tidal/tidal-oauth.json")
     cached_data = {
         "token_type": dict(data="token_type2"),
@@ -149,7 +150,7 @@ def test_failed_overall_login_throws_error(get_backend, tmp_path, mocker, config
     # Starting the mock web server will trigger login instantly (but login will fail)
     backend.web_auth_server.start_oauth_daemon.side_effect = login_failed
 
-    backend._active_session = session
+    backend._active_session.set(session)
     authf = tmp_path / "auth.json"
 
     with pytest.raises(ConnectionError):
@@ -160,7 +161,7 @@ def test_failed_overall_login_throws_error(get_backend, tmp_path, mocker, config
 
 def test_logs_in(get_backend, mocker, config):
     backend, _, _, session_factory, session = get_backend(config=config)
-    backend._active_session = session
+    backend._active_session.set(session)
 
     def login_success(*_, **__):
         session.check_login.return_value = True
@@ -192,7 +193,7 @@ def test_accessing_session_triggers_lazy_login(get_backend, mocker, config):
     backend.on_start()
 
     session.load_session_from_file.assert_not_called()
-    assert not backend._active_session.check_login()
+    assert not backend._active_session.get().check_login()
     assert backend.session  # accessing session will trigger login
     assert backend.session.check_login()
     session_factory.assert_called_once()

--- a/tests/test_login_hack.py
+++ b/tests/test_login_hack.py
@@ -24,7 +24,7 @@ def library_provider(get_backend, config, mocker):
     # Always start in logged-out state
     session.check_login.return_value = False
 
-    backend._active_session = session
+    backend._active_session.set(session)
 
     return backend, TidalLibraryProvider(backend=backend)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,33 @@
+import pytest
+
+from mopidy_tidal import types
+
+
+class TestLazy:
+    def test_raises_if_not_set(self):
+        with pytest.raises(ValueError):
+            types.Lazy().get()
+
+    def test_value_retrievable_after_setting(self):
+        lazy = types.Lazy()
+
+        lazy.set(123)
+
+        assert lazy.get() == lazy.get() == 123
+
+    def test_callback_used_when_value_missing(self):
+        called = 0
+
+        def init() -> int:
+            nonlocal called
+            called += 1
+            return 123
+
+        lazy = types.Lazy()
+
+        assert lazy.get_or(init) == 123
+        assert lazy.get_or(init) == 123
+        assert called == 1
+
+    def test_get_or_none_elides_inner_optionals(self):
+        assert types.Lazy(inner=None).get_or_none() is None

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -31,3 +31,6 @@ class TestLazy:
 
     def test_get_or_none_elides_inner_optionals(self):
         assert types.Lazy(inner=None).get_or_none() is None
+
+    def test_get_or_can_store_none(self):
+        assert types.Lazy().get_or(lambda: None) is None


### PR DESCRIPTION
This PR makes the `._active_session` attr type safe, i.e. gets rid of all the red underlines from your IDE telling you it might be None.

This isn't IMHO the best way to handle this kind of state, but it's quick to do and should make the dev experience nicer.  I could easily have done the others, I just wanted to show what it would look like.  Open to thoughts.

[This PR is a superset of #238]
