### PR TITLE
perf/blob io

### DIFF
--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -15,6 +15,7 @@ from tidalapi import __version__ as tidalapi_ver
 from mopidy_tidal import Extension, context, library, playback, playlists
 from mopidy_tidal import __version__ as mopidy_tidal_ver
 from mopidy_tidal.gstreamer_proxy import ThreadedProxy, mopidy_playback_cache
+from mopidy_tidal.types import Lazy
 from mopidy_tidal.web_auth_server import WebAuthServer
 
 logger = logging.getLogger(__name__)
@@ -34,7 +35,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
         self.playlists = playlists.TidalPlaylistsProvider(backend=self)
 
         # Session parameters
-        self._active_session: Optional[Session] = None
+        self._active_session: Lazy[Session] = Lazy()
         self._logged_in: bool = False
         self.uri_schemes: tuple[str] = ("tidal",)
         self._login_future: Optional[Future] = None
@@ -76,23 +77,25 @@ class TidalBackend(ThreadingActor, backend.Backend):
         return self._playback_cache.get_or(cache)
 
     @property
-    def session(self):
+    def session(self) -> Session:
         if not self.logged_in:
             self._login()
-        return self._active_session
+        return self._active_session.get()
 
     @property
-    def logged_in(self):
+    def logged_in(self) -> bool:
         if not self._logged_in:
-            if self._active_session.load_session_from_file(self.session_file_path):
+            if self._active_session.get().load_session_from_file(
+                self.session_file_path
+            ):
                 logger.info("Loaded TIDAL session from file %s", self.session_file_path)
                 self._logged_in = self.session_valid
         return self._logged_in
 
     @property
-    def session_valid(self):
+    def session_valid(self) -> bool:
         # Returns true when session is logged in and valid
-        return self._active_session.check_login()
+        return self._active_session.get().check_login()
 
     def on_start(self):
         logger.info("Mopidy-Tidal version: v%s", mopidy_tidal_ver)
@@ -137,13 +140,13 @@ class TidalBackend(ThreadingActor, backend.Backend):
         else:
             logger.info("Using default client id & client secret from python-tidal")
 
-        self._active_session = Session(config)
+        self._active_session.set(Session(config))
         if not self.lazy_connect:
             self._login()
 
     def _login(self):
         """Load session at startup or create a new session"""
-        if self._active_session.load_session_from_file(self.session_file_path):
+        if self._active_session.get().load_session_from_file(self.session_file_path):
             logger.info(
                 "Loaded existing TIDAL session from file %s...", self.session_file_path
             )
@@ -151,7 +154,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
             if not self.login_server_port:
                 # A. Default login, user must find login URL in Mopidy log
                 logger.info("Creating new session (OAuth)...")
-                self._active_session.login_oauth_simple(fn_print=logger.info)
+                self._active_session.get().login_oauth_simple(fn_print=logger.info)
             else:
                 # B. Interactive login, user must perform login using web auth
                 logger.info(
@@ -160,7 +163,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
                 )
                 if self.pkce_enabled:
                     # PKCE Login
-                    login_url = self._active_session.pkce_login_url()
+                    login_url = self._active_session.get().pkce_login_url()
                     logger.info(
                         "Please visit 'http://localhost:%s' to authenticate",
                         self.login_server_port,
@@ -173,6 +176,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
                 else:
                     # OAuth login
                     login_url = self.login_url
+                    assert login_url
                     logger.info(
                         "Please visit 'http://localhost:%s' or '%s' to authenticate",
                         self.login_server_port,
@@ -206,10 +210,10 @@ class TidalBackend(ThreadingActor, backend.Backend):
             try:
                 # Query for auth tokens
                 json: dict[str, Union[str, int]] = (
-                    self._active_session.pkce_get_auth_token(url_redirect)
+                    self._active_session.get().pkce_get_auth_token(url_redirect)
                 )
                 # Parse and set tokens.
-                self._active_session.process_auth_token(json, is_pkce_token=True)
+                self._active_session.get().process_auth_token(json, is_pkce_token=True)
                 self._logged_in = True
             except Exception:
                 raise ValueError("Response code is required for PKCE login!")
@@ -221,7 +225,7 @@ class TidalBackend(ThreadingActor, backend.Backend):
         if self.session_valid:
             # Only store current session if valid
             logger.info("TIDAL Login OK")
-            self._active_session.save_session_to_file(self.session_file_path)
+            self._active_session.get().save_session_to_file(self.session_file_path)
             self._logged_in = True
         else:
             logger.error("TIDAL Login Failed")
@@ -237,13 +241,13 @@ class TidalBackend(ThreadingActor, backend.Backend):
         """Start a new login sequence (if not active) and get the latest login URL"""
         if not self.pkce_enabled:
             if not self._logged_in and not self.logging_in:
-                login_url, self._login_future = self._active_session.login_oauth()
+                login_url, self._login_future = self._active_session.get().login_oauth()
                 self._login_future.add_done_callback(lambda *_: self._complete_login())
                 self._login_url = login_url.verification_uri_complete
             return f"https://{self._login_url}" if self._login_url else None
         else:
             if not self._logged_in and not self.web_auth_server.is_daemon_running:
-                login_url = self._active_session.pkce_login_url()
+                login_url = self._active_session.get().pkce_login_url()
                 self._login_url = "http://localhost:{}".format(self.login_server_port)
                 # Enable web server for interactive login + callback on form Submit
                 self.web_auth_server.set_callback(self._web_auth_callback)

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -5,6 +5,7 @@ import time
 from concurrent.futures import Future
 from pathlib import Path
 from typing import Optional, Union
+from urllib.parse import urlparse
 
 from mopidy import backend
 from pykka import ThreadingActor
@@ -60,7 +61,11 @@ class TidalBackend(ThreadingActor, backend.Backend):
     def playback_cache_for(self, uri: str) -> ThreadedProxy | None:
         def cache():
             if self._tidal_config["playback_cache"]:
+                track_url = self.session.track(uri.split(":")[-1]).get_url()
+                parsed = urlparse(track_url)
+
                 return mopidy_playback_cache(
+                    f"{parsed.scheme}://{parsed.netloc}",
                     Path(Extension.get_cache_dir(self._config)) / "playback.db",
                     self._tidal_config["playback_cache_max_entries"],
                     self._tidal_config["playback_cache_buffer_bytes"],

--- a/mopidy_tidal/backend.py
+++ b/mopidy_tidal/backend.py
@@ -42,6 +42,8 @@ class TidalBackend(ThreadingActor, backend.Backend):
         self.session_file_path: Path = Path("")
         self.web_auth_server: WebAuthServer = WebAuthServer()
 
+        self._playback_cache: Lazy[ThreadedProxy | None] = Lazy()
+
         # Config parameters
         # Lazy: Connect lazily, i.e. login only when user starts browsing TIDAL directories
         self.lazy_connect: bool = False
@@ -55,17 +57,18 @@ class TidalBackend(ThreadingActor, backend.Backend):
         # login_server_port: Port to use for login HTTP server, eg. <host_ip>:<port>. Default <host_ip>:8989
         self.login_server_port: int = 8989
 
-    @property
-    def playback_cache(self) -> ThreadedProxy | None:
-        if self._tidal_config["playback_cache"]:
-            path = Path(Extension.get_cache_dir(self._config)) / "playback.db"
-            return mopidy_playback_cache(
-                path,
-                self._tidal_config["playback_cache_max_entries"],
-                self._tidal_config["playback_cache_buffer_bytes"],
-            )
-        else:
-            return None
+    def playback_cache_for(self, uri: str) -> ThreadedProxy | None:
+        def cache():
+            if self._tidal_config["playback_cache"]:
+                return mopidy_playback_cache(
+                    Path(Extension.get_cache_dir(self._config)) / "playback.db",
+                    self._tidal_config["playback_cache_max_entries"],
+                    self._tidal_config["playback_cache_buffer_bytes"],
+                )
+            else:
+                return None
+
+        return self._playback_cache.get_or(cache)
 
     @property
     def session(self):
@@ -245,5 +248,5 @@ class TidalBackend(ThreadingActor, backend.Backend):
             return f"{self._login_url}" if self._login_url else None
 
     def on_stop(self) -> None:
-        if cache := self.playback_cache:
+        if cache := self._playback_cache.get_or_none():
             cache.stop()

--- a/mopidy_tidal/gstreamer_proxy/__init__.py
+++ b/mopidy_tidal/gstreamer_proxy/__init__.py
@@ -8,16 +8,14 @@ from .proxy import Proxy, ProxyConfig, ThreadedProxy
 
 @functools.cache
 def mopidy_playback_cache(
+    remote_url: str,
     path: Path,
     buffer_bytes: int,
     max_entries: int | None,
 ) -> ThreadedProxy:
     path.parent.mkdir(parents=True, exist_ok=True)
     proxy = Proxy(
-        ProxyConfig.build(
-            None,
-            "https://lgf.audio.tidal.com/",
-        ),
+        ProxyConfig.build(None, remote_url),
         lambda: SQLiteCache(sqlite3.connect(path), max_entries=max_entries),
         buffer_bytes=buffer_bytes,
     )

--- a/mopidy_tidal/gstreamer_proxy/cache.py
+++ b/mopidy_tidal/gstreamer_proxy/cache.py
@@ -7,7 +7,7 @@ calling code is expected to do something like:
 ```python
 with cache.insertion(path) as insertion:
    ...
-   insertion.save_head(head)
+   insertion.save_head(head, content_length)
    ...
    insertion.save_body_chunk(data, start)
    ...
@@ -58,7 +58,7 @@ class Entry(NamedTuple):
 
 @dataclass
 class Chunk:
-    data: Iterator[BytesIO]
+    data: Iterator[sqlite3.Blob]
     total: int
 
 

--- a/mopidy_tidal/gstreamer_proxy/cache.py
+++ b/mopidy_tidal/gstreamer_proxy/cache.py
@@ -60,7 +60,7 @@ class Entry(NamedTuple):
 
 @dataclass
 class Chunk:
-    data: Iterator[Bytes]
+    data: Iterator[BytesIO]
     total: int
 
 
@@ -369,9 +369,7 @@ RETURNING data
         cur = self.conn.cursor()
         if metadata := Metadata.lookup(cur, path):
             return Chunk(
-                data=ChunkedBuffer.from_db(self.conn, metadata).get_range(
-                    0, metadata.total
-                ),
+                data=ChunkedBuffer.from_db(self.conn, metadata).open_range(0),
                 total=metadata.total,
             )
 
@@ -379,9 +377,7 @@ RETURNING data
         cur = self.conn.cursor()
         if metadata := Metadata.lookup(cur, path):
             return Chunk(
-                data=ChunkedBuffer.from_db(self.conn, metadata).get_closed_range(
-                    start, end
-                ),
+                data=ChunkedBuffer.from_db(self.conn, metadata).open_range(start),
                 total=metadata.total,
             )
 

--- a/mopidy_tidal/gstreamer_proxy/cache.py
+++ b/mopidy_tidal/gstreamer_proxy/cache.py
@@ -147,8 +147,8 @@ class ChunkedBuffer:
         slices: list[ReadChunk] = []
         for slice in self.slices:
             if not slices:
-                if slice.start <= start and slice.end >= slice.start:
-                    slices.append(ReadChunk(slice.id, max(slice.start, start)))
+                if slice.end > start:
+                    slices.append(ReadChunk(slice.id, start - slice.start))
             else:
                 slices.append(ReadChunk(slice.id, 0))
 

--- a/mopidy_tidal/gstreamer_proxy/cache.py
+++ b/mopidy_tidal/gstreamer_proxy/cache.py
@@ -71,7 +71,7 @@ class Insertion(ABC):
     entire head before being sure how to handle the request."""
 
     @abstractmethod
-    def save_head(self, head: Head) -> None:
+    def save_head(self, head: Head, content_length: int) -> None:
         """Save the head for the given path."""
 
     @abstractmethod
@@ -177,22 +177,30 @@ def entry_id() -> EntryID:
 class SQLiteInsertion(Insertion):
     """An unfinialised insertion into a cache backed by sqlite."""
 
-    cur: sqlite3.Cursor
+    conn: sqlite3.Connection
     path: Path
     final: bool = False
     entry_id: EntryID = field(default_factory=entry_id)
+    row: int | None = None
 
-    def save_head(self, head: Head) -> None:
-        self.cur.execute(
+    def save_head(self, head: Head, content_length: int) -> None:
+        self.conn.execute(
             "INSERT INTO head (entry_id, path, data) VALUES (?, ?, ?)",
             (self.entry_id, self.path, head),
         )
+        self.row = self.conn.execute(
+            "INSERT INTO body (entry_id, path, start, data, len) VALUES (?, ?, 0, zeroblob(?), ?) RETURNING id",
+            (self.entry_id, self.path, content_length, content_length),
+        ).fetchone()[0]
 
     def save_body_chunk(self, data: Bytes, start: int) -> None:
-        self.cur.execute(
-            "INSERT INTO body (entry_id, path, start, data, len) VALUES (?, ?, ?, ?, ?)",
-            (self.entry_id, self.path, start, data, len(data)),
-        )
+        with self.writer() as fp:
+            fp.seek(start)
+            fp.write(data)
+
+    def writer(self) -> sqlite3.Blob:
+        assert self.row, "Writer called before .save_head()"
+        return self.conn.blobopen("body", "data", self.row)
 
     def finalise(self) -> None:
         self.final = True
@@ -386,7 +394,7 @@ RETURNING data
         with self.conn as conn:
             cur = conn.cursor()
 
-            insertion = SQLiteInsertion(cur, path)
+            insertion = SQLiteInsertion(conn, path)
             yield insertion
 
             if insertion.final:

--- a/mopidy_tidal/gstreamer_proxy/cache.py
+++ b/mopidy_tidal/gstreamer_proxy/cache.py
@@ -31,6 +31,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
+from io import BytesIO
 from logging import getLogger
 from typing import (
     Callable,
@@ -39,6 +40,7 @@ from typing import (
     NewType,
     Self,
     assert_never,
+    cast,
 )
 from uuid import uuid4
 
@@ -119,7 +121,7 @@ class Cache[I: Insertion](ABC):
 class ReadChunk(NamedTuple):
     id: int
     from_: int
-    to_: int
+    to: int
 
 
 @dataclass
@@ -127,7 +129,7 @@ class ChunkedBuffer:
     """A lazily resolved buffer over discrete chunks of data."""
 
     slices: list["StoredChunk"]
-    get_chunk: Callable[[ReadChunk], Bytes]
+    get_chunk: Callable[[int], BytesIO]
 
     def get_closed_range(self, start: int, end: int) -> Iterator[Bytes]:
         """Get a fully closed range from the backing data."""
@@ -136,7 +138,7 @@ class ChunkedBuffer:
     def get_range(self, start: int, end: int) -> Iterator[Bytes]:
         """Get a half-closed range from the backing data."""
 
-        slices = []
+        slices: list[ReadChunk] = []
         for slice in self.slices:
             if not slices:
                 if slice.start <= start and slice.end >= slice.start:
@@ -153,15 +155,14 @@ class ChunkedBuffer:
             raise KeyError("Data does not contain start range")
 
         for slice in slices:
-            yield self.get_chunk(slice)
+            with self.get_chunk(slice.id) as fp:
+                fp.seek(slice.from_)
+                yield fp.read(slice.to + 1 - start)
 
     @classmethod
     def from_db(cls, conn: sqlite3.Connection, metadata: "Metadata") -> Self:
-        def get_chunk(slice: ReadChunk) -> Bytes:
-            row, start, end = slice
-            with conn.blobopen("body", "data", row) as fp:
-                fp.seek(start)
-                return fp.read(end + 1 - start)
+        def get_chunk(row: int) -> BytesIO:
+            return cast(BytesIO, conn.blobopen("body", "data", row))
 
         return cls(metadata.ranges, get_chunk)
 

--- a/mopidy_tidal/gstreamer_proxy/cache.py
+++ b/mopidy_tidal/gstreamer_proxy/cache.py
@@ -44,7 +44,7 @@ from uuid import uuid4
 
 logger = getLogger()
 
-Bytes = bytes | bytearray
+Bytes = bytes | bytearray | memoryview
 Head = NewType("Head", bytes)
 Path = NewType("Path", bytes)
 TidalID = NewType("TidalID", str)

--- a/mopidy_tidal/gstreamer_proxy/cache.py
+++ b/mopidy_tidal/gstreamer_proxy/cache.py
@@ -159,7 +159,7 @@ class ChunkedBuffer:
 
         other_chunks = (
             shift_out(self.chunks(x))
-            for x in self.offsets[
+            for x in offsets[
                 offsets.index(start_offset) + 1 : offsets.index(end_offset)
             ]
         )

--- a/mopidy_tidal/gstreamer_proxy/cache.py
+++ b/mopidy_tidal/gstreamer_proxy/cache.py
@@ -121,7 +121,7 @@ class Cache[I: Insertion](ABC):
 class ReadChunk(NamedTuple):
     id: int
     from_: int
-    to: int
+    # to: int
 
 
 @dataclass
@@ -137,19 +137,20 @@ class ChunkedBuffer:
 
     def get_range(self, start: int, end: int) -> Iterator[Bytes]:
         """Get a half-closed range from the backing data."""
+        for fp in self.open_range(start):
+            yield fp.read(end)
+            end -= fp.tell()
+            if not end:
+                break
 
+    def open_range(self, start: int) -> Iterator[BytesIO]:
         slices: list[ReadChunk] = []
         for slice in self.slices:
             if not slices:
                 if slice.start <= start and slice.end >= slice.start:
-                    slices.append(
-                        ReadChunk(
-                            slice.id, max(slice.start, start), min(slice.end, end)
-                        )
-                    )
+                    slices.append(ReadChunk(slice.id, max(slice.start, start)))
             else:
-                if slice.start < end:
-                    slices.append(ReadChunk(slice.id, 0, min(slice.end, end)))
+                slices.append(ReadChunk(slice.id, 0))
 
         if not slices:
             raise KeyError("Data does not contain start range")
@@ -157,7 +158,7 @@ class ChunkedBuffer:
         for slice in slices:
             with self.get_chunk(slice.id) as fp:
                 fp.seek(slice.from_)
-                yield fp.read(slice.to + 1 - start)
+                yield fp
 
     @classmethod
     def from_db(cls, conn: sqlite3.Connection, metadata: "Metadata") -> Self:

--- a/mopidy_tidal/gstreamer_proxy/cache.py
+++ b/mopidy_tidal/gstreamer_proxy/cache.py
@@ -27,7 +27,6 @@ out which url we would try to get.
 """
 
 import sqlite3
-from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
@@ -35,7 +34,6 @@ from io import BytesIO
 from logging import getLogger
 from typing import (
     Callable,
-    ContextManager,
     NamedTuple,
     NewType,
     Self,
@@ -62,60 +60,6 @@ class Entry(NamedTuple):
 class Chunk:
     data: Iterator[BytesIO]
     total: int
-
-
-class Insertion(ABC):
-    """An insertion, i.e. a record we are saving as part of a proxying attempt.
-
-    We store the head and body chunks separately, since we have to receive the
-    entire head before being sure how to handle the request."""
-
-    @abstractmethod
-    def save_head(self, head: Head, content_length: int) -> None:
-        """Save the head for the given path."""
-
-    @abstractmethod
-    def save_body_chunk(self, data: Bytes, start: int) -> None:
-        """Save a chunk of the body for the given path at the given offset."""
-
-    @abstractmethod
-    def finalise(self) -> None:
-        """Mark this response as complete.
-
-        Implementations may choose to compact data here.
-        """
-
-
-class Cache[I: Insertion](ABC):
-    """A cache for the proxy, handling inserting and looking up remote
-    responses for local proxying."""
-
-    @abstractmethod
-    def get_head(self, path: Path) -> Head | None:
-        """Get the head if present for the given path."""
-
-    @abstractmethod
-    def get_body_chunk(self, path: Path, start: int, end: int) -> Chunk | None:
-        """Get a chunk of the body in the given half-closed range."""
-
-    @abstractmethod
-    def get_body(self, path: Path) -> Chunk | None:
-        """Get the whole body."""
-
-    @abstractmethod
-    def insertion(self, path: Path) -> ContextManager[I]: ...
-
-    def init(self) -> None:
-        """Initialise storage if needed."""
-
-    def lookup_path(self, id: TidalID) -> Path | None:
-        """Lookup the path for the given TidalID."""
-
-    def insert_path(self, id: TidalID, path: Path) -> None:
-        """Insert a TidalID -> Path mapping."""
-
-    def lookup_entry(self, id: TidalID) -> Entry | None:
-        """Query for a (finalised) entry + Path for this TidalID."""
 
 
 class ReadChunk(NamedTuple):
@@ -173,7 +117,7 @@ def entry_id() -> EntryID:
 
 
 @dataclass
-class SQLiteInsertion(Insertion):
+class SQLiteInsertion:
     """An unfinialised insertion into a cache backed by sqlite."""
 
     conn: sqlite3.Connection
@@ -256,7 +200,7 @@ class Metadata(NamedTuple):
 
 
 @dataclass
-class SQLiteCache(Cache[SQLiteInsertion]):
+class SQLiteCache:
     conn: sqlite3.Connection
     max_entries: int | None = None
 

--- a/mopidy_tidal/gstreamer_proxy/cache.py
+++ b/mopidy_tidal/gstreamer_proxy/cache.py
@@ -38,7 +38,6 @@ from typing import (
     NamedTuple,
     NewType,
     Self,
-    Sequence,
     assert_never,
 )
 from uuid import uuid4
@@ -117,73 +116,54 @@ class Cache[I: Insertion](ABC):
         """Query for a (finalised) entry + Path for this TidalID."""
 
 
+class ReadChunk(NamedTuple):
+    id: int
+    from_: int
+    to_: int
+
+
 @dataclass
 class ChunkedBuffer:
     """A lazily resolved buffer over discrete chunks of data."""
 
-    offsets: Sequence[int]
-    chunks: Callable[[int], Bytes]
+    slices: list["StoredChunk"]
+    get_chunk: Callable[[ReadChunk], Bytes]
+
+    def get_closed_range(self, start: int, end: int) -> Iterator[Bytes]:
+        """Get a fully closed range from the backing data."""
+        return self.get_range(start, end + 1)
 
     def get_range(self, start: int, end: int) -> Iterator[Bytes]:
-        """Get a (half closed) range from the backing data."""
-        end += 1  # http uses closed ranges
-        offsets = sorted(self.offsets)
+        """Get a half-closed range from the backing data."""
 
-        start_offset = None
-        for offset in reversed(offsets):
-            if offset <= start:
-                start_offset = offset
-                break
-        if start_offset is None:
+        slices = []
+        for slice in self.slices:
+            if not slices:
+                if slice.start <= start and slice.end >= slice.start:
+                    slices.append(
+                        ReadChunk(
+                            slice.id, max(slice.start, start), min(slice.end, end)
+                        )
+                    )
+            else:
+                if slice.start < end:
+                    slices.append(ReadChunk(slice.id, 0, min(slice.end, end)))
+
+        if not slices:
             raise KeyError("Data does not contain start range")
 
-        end_offset = None
-        for offset in offsets:
-            if offset >= end:
-                break
-            else:
-                end_offset = offset
-
-        if end_offset is None:
-            end_offset = offsets[-1]
-
-        sent = 0
-
-        def shift_out(
-            chunk: Bytes, start: int | None = None, end: int | None = None
-        ) -> Bytes:
-            nonlocal sent
-            data = chunk[start:end]
-            sent += len(data)
-            return data
-
-        other_chunks = (
-            shift_out(self.chunks(x))
-            for x in offsets[
-                offsets.index(start_offset) + 1 : offsets.index(end_offset)
-            ]
-        )
-
-        assert start >= start_offset
-        assert end >= end_offset
-
-        yield shift_out(self.chunks(start_offset), start=start - start_offset)
-        yield from other_chunks
-        if start_offset != end_offset:
-            yield shift_out(self.chunks(end_offset), end=end - end_offset)
-
-        logger.debug("Sent %s", sent)
-        assert sent == end - start, f"Sent {sent}, end={end}, start={start}"
+        for slice in slices:
+            yield self.get_chunk(slice)
 
     @classmethod
-    def from_db(cls, cur: sqlite3.Cursor, entry_id: EntryID, *offsets: int) -> Self:
-        def get_chunk(start: int) -> Bytes:
-            cur.execute(
-                "SELECT data FROM body WHERE entry_id=? AND start=?", (entry_id, start)
-            )
-            return cur.fetchone()[0]
+    def from_db(cls, conn: sqlite3.Connection, metadata: "Metadata") -> Self:
+        def get_chunk(slice: ReadChunk) -> Bytes:
+            row, start, end = slice
+            with conn.blobopen("body", "data", row) as fp:
+                fp.seek(start)
+                return fp.read(end + 1 - start)
 
-        return cls(offsets, get_chunk)
+        return cls(metadata.ranges, get_chunk)
 
 
 def entry_id() -> EntryID:
@@ -216,6 +196,12 @@ class SQLiteInsertion(Insertion):
         self.final = True
 
 
+class StoredChunk(NamedTuple):
+    id: int
+    start: int
+    end: int
+
+
 class Metadata(NamedTuple):
     """Metadata about the particular DB layout of this record.
 
@@ -223,7 +209,7 @@ class Metadata(NamedTuple):
     request (which may be partial)."""
 
     total: int
-    offsets: list[int]
+    ranges: list[StoredChunk]
     entry_id: EntryID
 
     @classmethod
@@ -237,7 +223,8 @@ class Metadata(NamedTuple):
       LIMIT 1
     )
     SELECT
-      start
+      id
+      , start
       , len
       , body.entry_id
     FROM body
@@ -246,15 +233,15 @@ class Metadata(NamedTuple):
         """,
             (path,),
         )
-        offsets = []
+        ranges = []
         total = 0
         entry_id = None
-        for start, length, entry_id in cur.fetchall():
-            offsets.append(start)
+        for id, start, length, entry_id in cur.fetchall():
+            ranges.append(StoredChunk(id, start, start + length))
             total += length
 
         if entry_id:
-            return cls(total, offsets, entry_id)
+            return cls(total, ranges, entry_id)
         else:
             return None
 
@@ -379,23 +366,21 @@ RETURNING data
     def get_body(self, path: Path) -> Chunk | None:
         cur = self.conn.cursor()
         if metadata := Metadata.lookup(cur, path):
-            total, offsets, entry_id = metadata
             return Chunk(
-                data=ChunkedBuffer.from_db(cur, entry_id, *offsets).get_range(
-                    0, total - 1
+                data=ChunkedBuffer.from_db(self.conn, metadata).get_range(
+                    0, metadata.total
                 ),
-                total=total,
+                total=metadata.total,
             )
 
     def get_body_chunk(self, path: Path, start: int, end: int) -> Chunk | None:
         cur = self.conn.cursor()
         if metadata := Metadata.lookup(cur, path):
-            total, offsets, entry_id = metadata
             return Chunk(
-                data=ChunkedBuffer.from_db(cur, entry_id, *offsets).get_range(
+                data=ChunkedBuffer.from_db(self.conn, metadata).get_closed_range(
                     start, end
                 ),
-                total=total,
+                total=metadata.total,
             )
 
     @contextmanager

--- a/mopidy_tidal/gstreamer_proxy/cache.py
+++ b/mopidy_tidal/gstreamer_proxy/cache.py
@@ -121,7 +121,6 @@ class Cache[I: Insertion](ABC):
 class ReadChunk(NamedTuple):
     id: int
     from_: int
-    # to: int
 
 
 @dataclass

--- a/mopidy_tidal/gstreamer_proxy/proxy.py
+++ b/mopidy_tidal/gstreamer_proxy/proxy.py
@@ -30,7 +30,7 @@ from typing import AsyncIterator, Awaitable, Callable, Iterator, Self
 from urllib.parse import urlparse, urlunparse
 
 from . import types
-from .cache import Cache, Head, Path
+from .cache import Head, Path, SQLiteCache
 
 logger = getLogger(__name__)
 
@@ -166,11 +166,11 @@ class Ignore:
 
 
 @dataclass
-class Proxy[C: Cache]:
+class Proxy:
     """A proxy server for a given remote server."""
 
     config: ProxyConfig
-    cache_factory: CacheFactory[C]
+    cache_factory: CacheFactory[SQLiteCache]
     started: bool = False
     event: asyncio.Event = field(default_factory=asyncio.Event)
     buffer_bytes: int = 1024 * 1024 * 16  # 16 MiB for now

--- a/mopidy_tidal/gstreamer_proxy/proxy.py
+++ b/mopidy_tidal/gstreamer_proxy/proxy.py
@@ -104,6 +104,9 @@ class Stream:
         while True:
             yield await self.readline(timeout)
 
+    def writer_buffered(self) -> int:
+        return self.tx.transport.get_write_buffer_size()
+
 
 @dataclass
 class Connection:
@@ -309,8 +312,10 @@ class Proxy[C: Cache]:
                             logger.debug("No more data to send")
                             break
                         else:
-                            await local.write(data)
                             logger.debug("writing cached data")
+                            local.tx.write(data)
+                            if local.writer_buffered() >= self.buffer_bytes:
+                                await local.tx.drain()
 
             # cache miss
             else:

--- a/mopidy_tidal/gstreamer_proxy/proxy.py
+++ b/mopidy_tidal/gstreamer_proxy/proxy.py
@@ -331,6 +331,7 @@ class Proxy:
                     head, content_length, keep_alive = await self.stream_head(
                         local, remote
                     )
+                    assert content_length
                     insertion.save_head(Head(bytes(head)), content_length)
 
                     buffer = types.Buffer.with_capacity(self.buffer_bytes)

--- a/mopidy_tidal/gstreamer_proxy/proxy.py
+++ b/mopidy_tidal/gstreamer_proxy/proxy.py
@@ -335,38 +335,34 @@ class Proxy:
                     insertion.save_head(Head(bytes(head)), content_length)
 
                     buffer = types.Buffer.with_capacity(self.buffer_bytes)
-                    offset = 0
                     read = 0
                     finished = False
 
-                    while not finished:
-                        data = await remote.read(self.buffer_bytes)
-                        read += len(data)
-                        if not data:  # socket closed
-                            break
-                        local.tx.write(data)
-                        buffer.extend(data)
-                        del data
+                    with insertion.writer() as cache_writer:
+                        while not finished:
+                            data = await remote.read(self.buffer_bytes)
+                            read += len(data)
+                            if not data:  # socket closed
+                                break
+                            local.tx.write(data)
+                            buffer.extend(data)
+                            del data
 
-                        finished = content_length is not None and read >= content_length
+                            finished = content_length is not None and read >= content_length
 
-                        # This rarely happens, since gstreamer is on localhost
-                        # an data is available to read as soon as we call
-                        # .write() above.  But if gstreamer *does* block, we're
-                        # better off blocking than running out of ram.
-                        gstreamer_buffer_full = (
-                            local.tx.transport.get_write_buffer_size()
-                            >= self.buffer_bytes
-                        )
-                        insertion_buffer_full = buffer.contains >= self.buffer_bytes
+                            # This rarely happens, since gstreamer is on localhost
+                            # and data is available to read as soon as we call
+                            # .write() above.  But if gstreamer *does* block, we're
+                            # better off blocking than running out of ram.
+                            gstreamer_buffer_full = local.writer_buffered() >= self.buffer_bytes
+                            insertion_buffer_full = buffer.contains >= self.buffer_bytes
 
-                        if gstreamer_buffer_full or finished:
-                            await local.tx.drain()
+                            if gstreamer_buffer_full or finished:
+                                await local.tx.drain()
 
-                        if insertion_buffer_full or finished:
-                            insertion.save_body_chunk(buffer.data(), offset)
-                            offset += buffer.contains
-                            buffer.clear()
+                            if insertion_buffer_full or finished:
+                                cache_writer.write(buffer.data())
+                                buffer.clear()
 
                     await remote.close()
                     if not keep_alive:

--- a/mopidy_tidal/gstreamer_proxy/proxy.py
+++ b/mopidy_tidal/gstreamer_proxy/proxy.py
@@ -284,7 +284,7 @@ class Proxy[C: Cache]:
                     range = range.expand(parsed.content_length)
                     start, end, _ = range
 
-                    chunks = self.cache.get_body_chunk(path, start, end)
+                    files = self.cache.get_body_chunk(path, start, end)
 
                     head_lines = head.splitlines()[1:-1]
                     del head
@@ -298,11 +298,16 @@ class Proxy[C: Cache]:
                     await local.write(b"\r\n".join(head_lines))
                 else:
                     await local.write(head)
-                    chunks = self.cache.get_body(path)
+                    files = self.cache.get_body(path)
 
-                assert chunks
-                for chunk in chunks.data:
-                    await local.write(chunk)
+                assert files
+                for file in files.data:
+                    while True:
+                        data = file.read(self.buffer_bytes)
+                        if not data:
+                            break
+                        else:
+                            await local.write(data)
 
             # cache miss
             else:

--- a/mopidy_tidal/gstreamer_proxy/proxy.py
+++ b/mopidy_tidal/gstreamer_proxy/proxy.py
@@ -117,7 +117,7 @@ class Connection:
         try:
             yield self
         except Exception:
-            logger.warning("Errored, closing connection")
+            logger.exception("Errored, closing connection")
             self.local.tx.close()
             if self.remote:
                 self.remote.tx.close()
@@ -303,11 +303,14 @@ class Proxy[C: Cache]:
                 assert files
                 for file in files.data:
                     while True:
+                        logger.debug("Reading cached data")
                         data = file.read(self.buffer_bytes)
                         if not data:
+                            logger.debug("No more data to send")
                             break
                         else:
                             await local.write(data)
+                            logger.debug("writing cached data")
 
             # cache miss
             else:
@@ -371,6 +374,8 @@ class Proxy[C: Cache]:
                             "Fetched whole record; finalising insertion %s", insertion
                         )
                         insertion.finalise()
+
+        logger.debug("Nothing more to do; handled connection")
 
 
 class ThreadedProxy:

--- a/mopidy_tidal/gstreamer_proxy/proxy.py
+++ b/mopidy_tidal/gstreamer_proxy/proxy.py
@@ -323,7 +323,7 @@ class Proxy[C: Cache]:
                     head, content_length, keep_alive = await self.stream_head(
                         local, remote
                     )
-                    insertion.save_head(Head(bytes(head)))
+                    insertion.save_head(Head(bytes(head)), content_length)
 
                     buffer = types.Buffer.with_capacity(self.buffer_bytes)
                     offset = 0

--- a/mopidy_tidal/gstreamer_proxy/types.py
+++ b/mopidy_tidal/gstreamer_proxy/types.py
@@ -4,6 +4,8 @@ from typing import NamedTuple, Self
 
 
 class FullRange(NamedTuple):
+    """Fully closed range from a total length."""
+
     start: int
     end: int
     total: int
@@ -13,6 +15,8 @@ class FullRange(NamedTuple):
 
 
 class Range(NamedTuple):
+    """Fully closed range between two points."""
+
     start: int | None
     end: int | None
 

--- a/mopidy_tidal/playback.py
+++ b/mopidy_tidal/playback.py
@@ -90,7 +90,7 @@ class TidalPlaybackProvider(backend.PlaybackProvider):
     def translate_uri(self, uri) -> str:
         logger.info("TIDAL uri: %s", uri)
 
-        if proxy := self.backend.playback_cache:
+        if proxy := self.backend.playback_cache_for(uri):
             id = cache.TidalID(uri)
             if entry := proxy.cache.lookup_entry(id):
                 return proxy.config.local_url(entry.path.decode())

--- a/mopidy_tidal/types.py
+++ b/mopidy_tidal/types.py
@@ -1,15 +1,18 @@
 from dataclasses import dataclass
+from enum import Enum
 from typing import Callable
+
+_UNSET = Enum("_UNSET", "_UNSET")
 
 
 @dataclass
 class Lazy[T]:
     """Type-safe T | None for lazy attributes."""
 
-    inner: T | None = None
+    inner: T | _UNSET = _UNSET._UNSET
 
     def get(self) -> T:
-        if self.inner is None:
+        if self.inner is _UNSET._UNSET:
             raise ValueError("Lazy value not set")
         else:
             return self.inner
@@ -18,9 +21,12 @@ class Lazy[T]:
         self.inner = val
 
     def get_or(self, init: Callable[[], T]) -> T:
-        if self.inner is None:
+        if self.inner is _UNSET._UNSET:
             self.set(init())
         return self.get()
 
     def get_or_none(self) -> T | None:
-        return self.inner
+        if self.inner is _UNSET._UNSET:
+            return None
+        else:
+            return self.inner

--- a/mopidy_tidal/types.py
+++ b/mopidy_tidal/types.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class Lazy[T]:
+    """Type-safe T | None for lazy attributes."""
+
+    inner: T | None = None
+
+    def get(self) -> T:
+        if self.inner is None:
+            raise ValueError("Lazy value not set")
+        else:
+            return self.inner
+
+    def set(self, val: T) -> None:
+        self.inner = val
+
+    def get_or(self, init: Callable[[], T]) -> T:
+        if self.inner is None:
+            self.set(init())
+        return self.get()
+
+    def get_or_none(self) -> T | None:
+        return self.inner

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -22,7 +22,8 @@ def test_backend_begins_in_correct_state(get_backend):
     backend, config, *_ = get_backend()
 
     assert backend.uri_schemes == ("tidal",)
-    assert not backend._active_session
+    with pytest.raises(ValueError):
+        backend._active_session.get()
     assert backend._config is config
 
 
@@ -36,7 +37,7 @@ def test_initial_login_caches_credentials(get_backend, config):
     # Starting the mock web server will trigger login instantly
     backend.web_auth_server.start_oauth_daemon.side_effect = login_success
 
-    backend._active_session = session
+    backend._active_session.set(session)
     authf = Path(config["core"]["data_dir"], "tidal/tidal-oauth.json")
     assert not authf.exists()
 
@@ -74,7 +75,7 @@ def test_login_after_failed_cached_credentials_overwrites_cached_credentials(
     # Starting the mock web server will trigger login instantly
     backend.web_auth_server.start_oauth_daemon.side_effect = login_success
 
-    backend._active_session = session
+    backend._active_session.set(session)
     authf = Path(config["core"]["data_dir"], "tidal/tidal-oauth.json")
     cached_data = {
         "token_type": dict(data="token_type2"),
@@ -114,7 +115,7 @@ def test_failed_login_does_not_overwrite_cached_credentials(
     # Starting the mock web server will trigger login instantly (but login will fail)
     backend.web_auth_server.start_oauth_daemon.side_effect = login_failed
 
-    backend._active_session = session
+    backend._active_session.set(session)
     authf = Path(config["core"]["data_dir"], "tidal/tidal-oauth.json")
     cached_data = {
         "token_type": dict(data="token_type2"),
@@ -149,7 +150,7 @@ def test_failed_overall_login_throws_error(get_backend, tmp_path, mocker, config
     # Starting the mock web server will trigger login instantly (but login will fail)
     backend.web_auth_server.start_oauth_daemon.side_effect = login_failed
 
-    backend._active_session = session
+    backend._active_session.set(session)
     authf = tmp_path / "auth.json"
 
     with pytest.raises(ConnectionError):
@@ -160,7 +161,7 @@ def test_failed_overall_login_throws_error(get_backend, tmp_path, mocker, config
 
 def test_logs_in(get_backend, mocker, config):
     backend, _, _, session_factory, session = get_backend(config=config)
-    backend._active_session = session
+    backend._active_session.set(session)
 
     def login_success(*_, **__):
         session.check_login.return_value = True
@@ -192,7 +193,7 @@ def test_accessing_session_triggers_lazy_login(get_backend, mocker, config):
     backend.on_start()
 
     session.load_session_from_file.assert_not_called()
-    assert not backend._active_session.check_login()
+    assert not backend._active_session.get().check_login()
     assert backend.session  # accessing session will trigger login
     assert backend.session.check_login()
     session_factory.assert_called_once()

--- a/tests/test_login_hack.py
+++ b/tests/test_login_hack.py
@@ -24,7 +24,7 @@ def library_provider(get_backend, config, mocker):
     # Always start in logged-out state
     session.check_login.return_value = False
 
-    backend._active_session = session
+    backend._active_session.set(session)
 
     return backend, TidalLibraryProvider(backend=backend)
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -297,7 +297,7 @@ class TestCache:
 
     def test_a_finalised_record_can_be_retrieved(self, cache: Cache[Insertion]):
         with cache.insertion(Path(b"foo")) as insertion:
-            insertion.save_head(Head(b"head"))
+            insertion.save_head(Head(b"head"), 8)
             insertion.save_body_chunk(b"body", 0)
             insertion.save_body_chunk(b"data", 4)
             insertion.finalise()
@@ -313,7 +313,7 @@ class TestCache:
         data = [f"body-{i}".encode() for i in range(128)]
 
         with cache.insertion(Path(b"foo")) as insertion:
-            insertion.save_head(Head(b"head"))
+            insertion.save_head(Head(b"head"), sum(len(x) for x in data))
             last = 0
             for chunk in data:
                 insertion.save_body_chunk(chunk, last)
@@ -329,7 +329,7 @@ class TestCache:
 
     def test_an_unfinalised_record_cannot_be_retrieved(self, cache: Cache[Insertion]):
         with cache.insertion(Path(b"foo")) as insertion:
-            insertion.save_head(Head(b"head"))
+            insertion.save_head(Head(b"head"), 8)
             insertion.save_body_chunk(b"body", 0)
             insertion.save_body_chunk(b"data", 4)
 
@@ -359,7 +359,7 @@ class TestCache:
         async def insert():
             async with semaphore:
                 with cache.insertion(Path(b"foo")) as insertion:
-                    insertion.save_head(Head(b"head"))
+                    insertion.save_head(Head(b"head"), 8)
                     await asyncio.sleep(0)
                     insertion.save_body_chunk(b"body", 0)
                     await asyncio.sleep(0)
@@ -391,7 +391,7 @@ class TestCache:
             async with semaphore:
                 with cache.insertion(Path(f"foo-{id}".encode())) as insertion:
                     await asyncio.sleep(0)
-                    insertion.save_head(Head(f"head-{id}".encode()))
+                    insertion.save_head(Head(f"head-{id}".encode()), 16)
                     await asyncio.sleep(0)
                     insertion.save_body_chunk(b"body", 0)
                     await asyncio.sleep(0)
@@ -433,7 +433,7 @@ class TestSQLiteCache:
             async with semaphore:
                 with cache.insertion(Path(f"foo-{id}".encode())) as insertion:
                     await asyncio.sleep(0)
-                    insertion.save_head(Head(f"head-{id}".encode()))
+                    insertion.save_head(Head(f"head-{id}".encode()), 16)
                     await asyncio.sleep(0)
                     insertion.save_body_chunk(b"body", 0)
                     await asyncio.sleep(0)
@@ -468,7 +468,7 @@ class TestSQLiteCache:
             async with semaphore:
                 with cache.insertion(Path(f"foo-{id}".encode())) as insertion:
                     await asyncio.sleep(0)
-                    insertion.save_head(Head(f"head-{id}".encode()))
+                    insertion.save_head(Head(f"head-{id}".encode()), 16)
                     await asyncio.sleep(0)
                     insertion.save_body_chunk(b"body", 0)
                     await asyncio.sleep(0)
@@ -493,7 +493,7 @@ class TestSQLiteCache:
         cache.init()
 
         with cache.insertion(Path(b"foo")) as insertion:
-            insertion.save_head(Head(b"head"))
+            insertion.save_head(Head(b"head"), 8)
             insertion.save_body_chunk(b"body", 0)
             insertion.save_body_chunk(b"data", 4)
             assert conn.execute("select count(*) from head").fetchone()[0] == 1
@@ -516,7 +516,7 @@ class TestSQLiteCache:
         cache.init()
 
         with cache.insertion(Path(b"foo")) as insertion:
-            insertion.save_head(Head(b"head"))
+            insertion.save_head(Head(b"head"), 8)
             insertion.save_body_chunk(b"body", 0)
             insertion.save_body_chunk(b"data", 4)
             assert conn.execute("select count(*) from head").fetchone()[0] == 1
@@ -544,7 +544,7 @@ class TestSQLiteCache:
         cache.init()
 
         with cache.insertion(Path(b"foo")) as insertion:
-            insertion.save_head(Head(b"head"))
+            insertion.save_head(Head(b"head"), 4)
             insertion.save_body_chunk(b"body", 0)
             insertion.finalise()
 
@@ -567,7 +567,7 @@ class TestSQLiteCache:
 
         for i in range(4):
             with cache.insertion(Path(f"foo-{i}".encode())) as insertion:
-                insertion.save_head(Head(b"head"))
+                insertion.save_head(Head(b"head"), 4)
                 insertion.save_body_chunk(b"body", 0)
                 insertion.finalise()
 
@@ -585,7 +585,7 @@ class TestSQLiteCache:
 
         for key in keys:
             with cache.insertion(key) as insertion:
-                insertion.save_head(Head(b"head"))
+                insertion.save_head(Head(b"head"), 4)
                 insertion.save_body_chunk(b"body", 0)
                 insertion.finalise()
 
@@ -608,7 +608,7 @@ class TestSQLiteCache:
 
         for key in keys[:3]:
             with cache.insertion(key) as insertion:
-                insertion.save_head(Head(b"head"))
+                insertion.save_head(Head(b"head"), 4)
                 insertion.save_body_chunk(b"body", 0)
                 insertion.finalise()
 
@@ -618,7 +618,7 @@ class TestSQLiteCache:
 
         for key in keys[3:]:
             with cache.insertion(key) as insertion:
-                insertion.save_head(Head(b"head"))
+                insertion.save_head(Head(b"head"), 4)
                 insertion.save_body_chunk(b"body", 0)
                 insertion.finalise()
 
@@ -664,7 +664,7 @@ class TestPathCache:
 
         cache.insert_path(TidalID("tidal:track:0:0:0"), path)
         with cache.insertion(path) as insertion:
-            insertion.save_head(Head(b"head"))
+            insertion.save_head(Head(b"head"), 4)
             insertion.save_body_chunk(b"body", 0)
 
             assert not cache.lookup_entry(TidalID("tidal:track:0:0:0"))
@@ -678,7 +678,7 @@ class TestPathCache:
 
         cache.insert_path(TidalID("tidal:track:0:0:0"), path)
         with cache.insertion(path) as insertion:
-            insertion.save_head(Head(b"head"))
+            insertion.save_head(Head(b"head"), 4)
             insertion.save_body_chunk(b"body", 0)
             insertion.finalise()
 
@@ -696,14 +696,14 @@ class TestPathCache:
 
         cache.insert_path(TidalID("tidal:track:0:0:0"), path)
         with cache.insertion(path) as insertion:
-            insertion.save_head(Head(b"head"))
+            insertion.save_head(Head(b"head"), 4)
             insertion.save_body_chunk(b"body", 0)
             insertion.finalise()
 
         assert cache.lookup_entry(TidalID("tidal:track:0:0:0"))
 
         with cache.insertion(Path("/bar/baz")) as insertion:
-            insertion.save_head(Head(b"head"))
+            insertion.save_head(Head(b"head"), 4)
             insertion.save_body_chunk(b"body", 0)
             insertion.finalise()
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -451,7 +451,10 @@ class TestSQLiteCache:
         conn = sqlite3.connect(tmp_path / "foo.db")
 
         assert conn.execute("select count(*) from head").fetchone()[0] == 1
-        assert conn.execute("select count(*) from body").fetchone()[0] == 3
+        assert conn.execute("select count(*), is_final from body").fetchone() == (
+            1,
+            True,
+        )
 
     @parametrize("n_concurrent", [1, 2, 8, 24, 64, 128])
     async def test_incomplete_insertion_do_not_prevent_complete_insertions_from_persisting_on_the_conn(
@@ -482,7 +485,10 @@ class TestSQLiteCache:
         await asyncio.gather(*(insert(i) for i in range(128)))
 
         assert conn.execute("select count(*) from head").fetchone()[0] == 1
-        assert conn.execute("select count(*) from body").fetchone()[0] == 3
+        assert conn.execute("select count(*), is_final from body").fetchone() == (
+            1,
+            True,
+        )
 
     async def test_incomplete_insertion_is_not_left_in_cache(
         self, tmp_path: pathlib.Path
@@ -497,7 +503,10 @@ class TestSQLiteCache:
             insertion.save_body_chunk(b"body", 0)
             insertion.save_body_chunk(b"data", 4)
             assert conn.execute("select count(*) from head").fetchone()[0] == 1
-            assert conn.execute("select count(*) from body").fetchone()[0] == 2
+            assert conn.execute("select count(*), is_final from body").fetchone() == (
+                1,
+                False,
+            )
 
         del cache, conn
 
@@ -520,7 +529,10 @@ class TestSQLiteCache:
             insertion.save_body_chunk(b"body", 0)
             insertion.save_body_chunk(b"data", 4)
             assert conn.execute("select count(*) from head").fetchone()[0] == 1
-            assert conn.execute("select count(*) from body").fetchone()[0] == 2
+            assert conn.execute("select count(*), is_final from body").fetchone() == (
+                1,
+                False,
+            )
 
         assert conn.execute("select count(*) from head").fetchone()[0] == 0
         assert conn.execute("select count(*) from body").fetchone()[0] == 0

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -306,7 +306,7 @@ class TestCache:
 
         lookup = cache.get_body(Path(b"foo"))
         assert lookup
-        body = b"".join(lookup.data)
+        body = b"".join(x.read() for x in lookup.data)
         assert body == b"bodydata"
 
     def test_a_long_finalised_record_can_be_retrieved(self, cache: Cache[Insertion]):
@@ -324,7 +324,7 @@ class TestCache:
 
         lookup = cache.get_body(Path(b"foo"))
         assert lookup
-        body = b"".join(lookup.data)
+        body = b"".join(x.read() for x in lookup.data)
         assert body == b"".join(data)
 
     def test_an_unfinalised_record_cannot_be_retrieved(self, cache: Cache[Insertion]):
@@ -373,12 +373,12 @@ class TestCache:
         assert cache.get_head(Path(b"foo")) == b"head"
         lookup = cache.get_body(Path(b"foo"))
         assert lookup
-        body = b"".join(lookup.data)
+        body = b"".join(x.read() for x in lookup.data)
         assert body == b"bodydata"
 
         lookup = cache.get_body(Path(b"foo"))
         assert lookup
-        body = b"".join(lookup.data)
+        body = b"".join(x.read() for x in lookup.data)
         assert body == b"bodydata"
 
     @parametrize("n_concurrent", [2, 8, 24, 64, 128])
@@ -411,7 +411,7 @@ class TestCache:
 
             lookup = cache.get_body(path)
             assert lookup
-            body = b"".join(lookup.data)
+            body = b"".join(x.read() for x in lookup.data)
             assert body[:8] == b"bodydata"
             assert int.from_bytes(body[8:]) == id
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -16,9 +16,7 @@ from pytest_cases import fixture, parametrize, parametrize_with_cases
 from pytest_httpserver import HTTPServer
 
 from mopidy_tidal.gstreamer_proxy.cache import (
-    Cache,
     Head,
-    Insertion,
     Path,
     SQLiteCache,
     TidalID,
@@ -279,23 +277,22 @@ class TestBuffer:
         assert buffer.data() == b"67890"
 
 
-class CacheCases:
-    def case_sqlite(self) -> SQLiteCache:
-        db = sqlite3.connect(":memory:")
-        cache = SQLiteCache(db)
-        cache.init()
-        return cache
+@fixture()
+def cache() -> SQLiteCache:
+    db = sqlite3.connect(":memory:")
+    cache = SQLiteCache(db)
+    cache.init()
+    return cache
 
 
-@parametrize_with_cases("cache", cases=CacheCases)
 class TestCache:
-    def test_an_empty_cache_has_no_heads(self, cache: Cache):
+    def test_an_empty_cache_has_no_heads(self, cache: SQLiteCache):
         assert not cache.get_head(Path(b"foo"))
 
-    def test_an_empty_cache_has_no_bodies(self, cache: Cache):
+    def test_an_empty_cache_has_no_bodies(self, cache: SQLiteCache):
         assert not cache.get_body(Path(b"foo"))
 
-    def test_a_finalised_record_can_be_retrieved(self, cache: Cache[Insertion]):
+    def test_a_finalised_record_can_be_retrieved(self, cache: SQLiteCache):
         with cache.insertion(Path(b"foo")) as insertion:
             insertion.save_head(Head(b"head"), 8)
             insertion.save_body_chunk(b"body", 0)
@@ -309,7 +306,7 @@ class TestCache:
         body = b"".join(x.read() for x in lookup.data)
         assert body == b"bodydata"
 
-    def test_a_long_finalised_record_can_be_retrieved(self, cache: Cache[Insertion]):
+    def test_a_long_finalised_record_can_be_retrieved(self, cache: SQLiteCache):
         data = [f"body-{i}".encode() for i in range(128)]
 
         with cache.insertion(Path(b"foo")) as insertion:
@@ -327,7 +324,7 @@ class TestCache:
         body = b"".join(x.read() for x in lookup.data)
         assert body == b"".join(data)
 
-    def test_an_unfinalised_record_cannot_be_retrieved(self, cache: Cache[Insertion]):
+    def test_an_unfinalised_record_cannot_be_retrieved(self, cache: SQLiteCache):
         with cache.insertion(Path(b"foo")) as insertion:
             insertion.save_head(Head(b"head"), 8)
             insertion.save_body_chunk(b"body", 0)
@@ -338,7 +335,7 @@ class TestCache:
 
     @parametrize("n_concurrent", [2, 8, 24, 64, 128])
     async def test_the_same_path_can_be_inserted_concurrently(
-        self, cache: Cache[Insertion], n_concurrent: int
+        self, cache: SQLiteCache, n_concurrent: int
     ):
         """This is not particularly useful, but it's better to insert the path
         than to e.g. corrupt the data. So long as we return a complete record,
@@ -383,7 +380,7 @@ class TestCache:
 
     @parametrize("n_concurrent", [2, 8, 24, 64, 128])
     async def test_different_paths_can_be_inserted_concurrently(
-        self, cache: Cache[Insertion], n_concurrent: int
+        self, cache: SQLiteCache, n_concurrent: int
     ):
         semaphore = asyncio.Semaphore(n_concurrent)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,33 @@
+import pytest
+
+from mopidy_tidal import types
+
+
+class TestLazy:
+    def test_raises_if_not_set(self):
+        with pytest.raises(ValueError):
+            types.Lazy().get()
+
+    def test_value_retrievable_after_setting(self):
+        lazy = types.Lazy()
+
+        lazy.set(123)
+
+        assert lazy.get() == lazy.get() == 123
+
+    def test_callback_used_when_value_missing(self):
+        called = 0
+
+        def init() -> int:
+            nonlocal called
+            called += 1
+            return 123
+
+        lazy = types.Lazy()
+
+        assert lazy.get_or(init) == 123
+        assert lazy.get_or(init) == 123
+        assert called == 1
+
+    def test_get_or_none_elides_inner_optionals(self):
+        assert types.Lazy(inner=None).get_or_none() is None

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -31,3 +31,6 @@ class TestLazy:
 
     def test_get_or_none_elides_inner_optionals(self):
         assert types.Lazy(inner=None).get_or_none() is None
+
+    def test_get_or_can_store_none(self):
+        assert types.Lazy().get_or(lambda: None) is None


### PR DESCRIPTION
This PR is on top of #239, though if that's rejected it will rebase on top of #238.

It replaces multiple chunk-sized records with a single record for the body, allocated up front with the correct size, and then buffered with sqlite's blobopen function (which returns a file pointer to a blob record).  I've kept it compatible with the old format and it continues to play cached data in that format.

This should lead to improved DB performance, as previously the DB fragmented very quickly, and hopefully will lead to reduced RAM usage.

I've also taken the opportunity to clean up dead / redundant code from the development process of the proxy.

From using the cache for several months I've noticed:

- RAM usage sometimes kills mopidy on my raspberry pi (the ram headroom is marginal anyway and I'm running a pretty hevayweight NixOS I should tune, but it's definitely cache related)
- if gstreamer crashes, pykka can re-spawn a thread with a now stale DB connection

Gstreamer crashes (based on seeking around aggressively) seem to go away when I used the default HTTP sink and not curl.
