### PR TITLE
Add HTTP API for managing TIDAL favorites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+#### Unreleased
+
+- Feature: HTTP API for managing the user's TIDAL favorites (albums, tracks,
+  artists, playlists). Mounted at `/tidal/favorites/<kind>s` by the Mopidy
+  HTTP frontend; supports `GET`, `POST { "id": "<id>" }` and
+  `DELETE /tidal/favorites/<kind>s/<id>`. Lets Mopidy clients add/remove
+  favorites without re-implementing TIDAL OAuth. (Fixes: #241)
+
 #### v0.3.13
 
 - Bugfix: Avoid MPD manifest parsing to fix regression with new/incompatible TIDAL MPD

--- a/mopidy_tidal/__init__.py
+++ b/mopidy_tidal/__init__.py
@@ -45,5 +45,10 @@ class Extension(ext.Extension):
 
     def setup(self, registry):
         from .backend import TidalBackend
+        from .web import make_app
 
         registry.add("backend", TidalBackend)
+        registry.add(
+            "http:app",
+            {"name": self.ext_name, "factory": make_app},
+        )

--- a/mopidy_tidal/web.py
+++ b/mopidy_tidal/web.py
@@ -1,0 +1,120 @@
+"""HTTP endpoints for managing the user's TIDAL favorites.
+
+Mounted under ``/tidal/`` by Mopidy's HTTP frontend. Routes:
+
+    POST   /tidal/favorites/<kind>s          { "id": "12345" }
+    DELETE /tidal/favorites/<kind>s/<id>
+    GET    /tidal/favorites/<kind>s
+
+where ``<kind>`` is one of ``album``, ``track``, ``artist``, ``playlist``.
+
+Authentication is implicit: the handlers reuse the ``tidalapi.Session`` already
+held by the ``TidalBackend`` actor, so clients don't re-implement OAuth.
+"""
+
+from __future__ import unicode_literals
+
+import json
+import logging
+
+import pykka
+from tornado.web import HTTPError, RequestHandler
+
+logger = logging.getLogger(__name__)
+
+# Tidal entity kinds we expose. Each must map to ``tidalapi.Favorites`` having
+# methods ``add_<kind>``, ``remove_<kind>`` and an attribute ``<kind>s``.
+KINDS = ("album", "track", "artist", "playlist")
+
+
+def make_app(config, core):
+    """Mopidy ``http:app`` factory. Looks up the running TidalBackend actor
+    and binds it into every handler so requests can reach the session."""
+
+    # Late import: backend.py imports from this package at module load and
+    # would cause a circular import otherwise.
+    from mopidy_tidal.backend import TidalBackend
+
+    refs = pykka.ActorRegistry.get_by_class(TidalBackend)
+    if not refs:
+        # Should not happen: this factory is only invoked when the extension
+        # is enabled, which also instantiates the backend.
+        raise RuntimeError(
+            "TidalBackend actor not running; cannot register HTTP routes"
+        )
+    backend = refs[0].proxy()
+
+    common = {"backend": backend}
+    return [
+        (
+            r"/favorites/(album|track|artist|playlist)s",
+            FavoritesCollectionHandler,
+            common,
+        ),
+        (
+            r"/favorites/(album|track|artist|playlist)s/([^/]+)",
+            FavoritesItemHandler,
+            common,
+        ),
+    ]
+
+
+class _Base(RequestHandler):
+    def initialize(self, backend):
+        self.backend = backend
+
+    def write_error(self, status_code, **kwargs):
+        self.set_header("Content-Type", "application/json")
+        self.finish(json.dumps({"error": self._reason}))
+
+    def _session(self):
+        # ``backend.session`` is a property that drives the (lazy) login flow.
+        # Going through the Pykka proxy serialises access on the backend
+        # actor thread; ``.get()`` unwraps the Future on the IOLoop thread.
+        try:
+            session = self.backend.session.get()
+        except Exception as e:
+            logger.exception("tidal session unavailable")
+            raise HTTPError(503, reason=f"tidal session unavailable: {e}")
+        if session is None or getattr(session, "user", None) is None:
+            raise HTTPError(503, reason="tidal session not logged in")
+        return session
+
+
+class FavoritesCollectionHandler(_Base):
+    def get(self, kind):
+        session = self._session()
+        items = getattr(session.user.favorites, f"{kind}s")()
+        self.set_header("Content-Type", "application/json")
+        self.write(json.dumps([_summarize(x) for x in items or []]))
+
+    def post(self, kind):
+        session = self._session()
+        try:
+            body = json.loads(self.request.body or b"{}")
+        except json.JSONDecodeError as e:
+            raise HTTPError(400, reason=f"invalid JSON: {e}")
+        item_id = body.get("id")
+        if not item_id:
+            raise HTTPError(400, reason="missing 'id' in body")
+        getattr(session.user.favorites, f"add_{kind}")(item_id)
+        self.set_status(204)
+
+
+class FavoritesItemHandler(_Base):
+    def delete(self, kind, item_id):
+        session = self._session()
+        getattr(session.user.favorites, f"remove_{kind}")(item_id)
+        self.set_status(204)
+
+
+def _summarize(obj):
+    """tidalapi objects don't JSON-serialise cleanly; pull a small summary."""
+    summary = {"id": str(getattr(obj, "id", ""))}
+    name = getattr(obj, "name", None)
+    if name:
+        summary["name"] = name
+    artist = getattr(obj, "artist", None)
+    if artist is not None:
+        summary["artist"] = getattr(artist, "name", None)
+    return summary

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -41,7 +41,26 @@ def test_extension_setup_registers_tidal_backend(mocker):
 
     ext.setup(registry)
 
-    registry.add.assert_called_once()
-    plugin_type, obj = registry.add.mock_calls[0].args
-    assert plugin_type == "backend"
+    backend_calls = [
+        c for c in registry.add.mock_calls if c.args and c.args[0] == "backend"
+    ]
+    assert len(backend_calls) == 1
+    _, obj = backend_calls[0].args
     assert issubclass(obj, TidalBackend)
+
+
+def test_extension_setup_registers_http_app(mocker):
+    from mopidy_tidal.web import make_app
+
+    ext = Extension()
+    registry = mocker.Mock()
+
+    ext.setup(registry)
+
+    http_calls = [
+        c for c in registry.add.mock_calls if c.args and c.args[0] == "http:app"
+    ]
+    assert len(http_calls) == 1
+    _, spec = http_calls[0].args
+    assert spec["name"] == "tidal"
+    assert spec["factory"] is make_app

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,269 @@
+"""Tests for the HTTP favorites API in :mod:`mopidy_tidal.web`."""
+
+from __future__ import unicode_literals
+
+import json
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from tornado.httputil import HTTPServerRequest
+from tornado.web import Application, HTTPError
+
+from mopidy_tidal import web
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _make_request(body=b"", method="GET"):
+    request = Mock(spec=HTTPServerRequest)
+    request.method = method
+    request.body = body
+    request.headers = {}
+    request.connection = Mock()
+    request.uri = "/"
+    request.host = "localhost"
+    request.full_url = lambda: "http://localhost/"
+    request.supports_http_1_1 = lambda: True
+    request.version = "HTTP/1.1"
+    return request
+
+
+def _make_handler(handler_cls, backend, body=b"", method="GET"):
+    """Instantiate a Tornado RequestHandler bypassing the IOLoop plumbing.
+
+    We override the side-effectful response methods (``write``, ``set_status``,
+    ``set_header``, ``finish``) with mocks so the test can inspect what the
+    handler tried to send.
+    """
+    app = Application()
+    request = _make_request(body=body, method=method)
+    handler = handler_cls(app, request, backend=backend)
+    handler.write = Mock()
+    handler.set_status = Mock()
+    handler.set_header = Mock()
+    handler.finish = Mock()
+    return handler
+
+
+def _written_json(handler):
+    handler.write.assert_called_once()
+    payload = handler.write.call_args.args[0]
+    return json.loads(payload)
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def favorites():
+    return MagicMock()
+
+
+@pytest.fixture
+def session(favorites):
+    user = Mock(favorites=favorites)
+    return Mock(user=user)
+
+
+@pytest.fixture
+def backend(session):
+    """A stand-in for the Pykka proxy returned by ``ActorRegistry``.
+
+    ``backend.session`` returns a stub Future whose ``.get()`` yields the
+    mocked :class:`tidalapi.Session`.
+    """
+    future = Mock()
+    future.get.return_value = session
+    proxy = Mock()
+    proxy.session = future
+    return proxy
+
+
+# ── _summarize ─────────────────────────────────────────────────────────────
+
+
+def test_summarize_minimal_object():
+    assert web._summarize(Mock(spec=[])) == {"id": ""}
+
+
+def test_summarize_includes_name_when_present():
+    obj = Mock(spec=["id", "name"], id=42)
+    obj.name = "Discovery"
+    result = web._summarize(obj)
+    assert result == {"id": "42", "name": "Discovery"}
+
+
+def test_summarize_includes_artist_name_when_present():
+    artist = Mock(name="Daft Punk")
+    artist.name = "Daft Punk"
+    obj = Mock(id=42, name="Discovery", artist=artist)
+    result = web._summarize(obj)
+    assert result["artist"] == "Daft Punk"
+
+
+# ── make_app ───────────────────────────────────────────────────────────────
+
+
+def test_make_app_returns_route_specs(mocker):
+    backend_ref = Mock()
+    backend_ref.proxy.return_value = Mock()
+    mocker.patch.object(
+        web.pykka.ActorRegistry, "get_by_class", return_value=[backend_ref]
+    )
+
+    routes = web.make_app(config={}, core=Mock())
+
+    assert len(routes) == 2
+    pattern_collection, handler_collection, init_collection = routes[0]
+    pattern_item, handler_item, init_item = routes[1]
+    assert handler_collection is web.FavoritesCollectionHandler
+    assert handler_item is web.FavoritesItemHandler
+    assert "backend" in init_collection
+    assert "backend" in init_item
+
+
+def test_make_app_raises_when_no_backend(mocker):
+    mocker.patch.object(web.pykka.ActorRegistry, "get_by_class", return_value=[])
+
+    with pytest.raises(RuntimeError, match="TidalBackend"):
+        web.make_app(config={}, core=Mock())
+
+
+# ── _Base._session ─────────────────────────────────────────────────────────
+
+
+def test_session_returns_session_when_logged_in(backend, session):
+    handler = _make_handler(web.FavoritesCollectionHandler, backend)
+    assert handler._session() is session
+
+
+def test_session_raises_503_when_session_is_none(backend):
+    backend.session.get.return_value = None
+    handler = _make_handler(web.FavoritesCollectionHandler, backend)
+    with pytest.raises(HTTPError) as exc:
+        handler._session()
+    assert exc.value.status_code == 503
+
+
+def test_session_raises_503_when_user_missing(backend):
+    backend.session.get.return_value = Mock(user=None)
+    handler = _make_handler(web.FavoritesCollectionHandler, backend)
+    with pytest.raises(HTTPError) as exc:
+        handler._session()
+    assert exc.value.status_code == 503
+
+
+def test_session_raises_503_when_proxy_raises(backend):
+    backend.session.get.side_effect = TimeoutError("login timed out")
+    handler = _make_handler(web.FavoritesCollectionHandler, backend)
+    with pytest.raises(HTTPError) as exc:
+        handler._session()
+    assert exc.value.status_code == 503
+
+
+# ── FavoritesCollectionHandler.get ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize("kind", web.KINDS)
+def test_collection_get_returns_summaries(backend, favorites, kind):
+    item = Mock(spec=["id", "name"], id=42)
+    item.name = "Discovery"
+    getattr(favorites, f"{kind}s").return_value = [item]
+
+    handler = _make_handler(web.FavoritesCollectionHandler, backend)
+    handler.get(kind)
+
+    handler.set_header.assert_called_with("Content-Type", "application/json")
+    payload = _written_json(handler)
+    assert payload == [{"id": "42", "name": "Discovery"}]
+
+
+def test_collection_get_handles_empty(backend, favorites):
+    favorites.albums.return_value = []
+    handler = _make_handler(web.FavoritesCollectionHandler, backend)
+    handler.get("album")
+    assert _written_json(handler) == []
+
+
+def test_collection_get_tolerates_none_from_tidal(backend, favorites):
+    """``tidalapi`` occasionally returns ``None`` instead of an empty list."""
+    favorites.albums.return_value = None
+    handler = _make_handler(web.FavoritesCollectionHandler, backend)
+    handler.get("album")
+    assert _written_json(handler) == []
+
+
+# ── FavoritesCollectionHandler.post ────────────────────────────────────────
+
+
+@pytest.mark.parametrize("kind", web.KINDS)
+def test_collection_post_adds_favorite(backend, favorites, kind):
+    handler = _make_handler(
+        web.FavoritesCollectionHandler,
+        backend,
+        body=b'{"id": "12345"}',
+        method="POST",
+    )
+    handler.post(kind)
+    getattr(favorites, f"add_{kind}").assert_called_once_with("12345")
+    handler.set_status.assert_called_once_with(204)
+
+
+def test_collection_post_rejects_invalid_json(backend):
+    handler = _make_handler(
+        web.FavoritesCollectionHandler,
+        backend,
+        body=b"not-json",
+        method="POST",
+    )
+    with pytest.raises(HTTPError) as exc:
+        handler.post("album")
+    assert exc.value.status_code == 400
+
+
+def test_collection_post_rejects_missing_id(backend):
+    handler = _make_handler(
+        web.FavoritesCollectionHandler,
+        backend,
+        body=b"{}",
+        method="POST",
+    )
+    with pytest.raises(HTTPError) as exc:
+        handler.post("album")
+    assert exc.value.status_code == 400
+
+
+def test_collection_post_rejects_empty_body(backend):
+    handler = _make_handler(
+        web.FavoritesCollectionHandler,
+        backend,
+        body=b"",
+        method="POST",
+    )
+    with pytest.raises(HTTPError) as exc:
+        handler.post("album")
+    assert exc.value.status_code == 400
+
+
+# ── FavoritesItemHandler.delete ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("kind", web.KINDS)
+def test_item_delete_removes_favorite(backend, favorites, kind):
+    handler = _make_handler(web.FavoritesItemHandler, backend, method="DELETE")
+    handler.delete(kind, "12345")
+    getattr(favorites, f"remove_{kind}").assert_called_once_with("12345")
+    handler.set_status.assert_called_once_with(204)
+
+
+# ── write_error ────────────────────────────────────────────────────────────
+
+
+def test_write_error_emits_json():
+    handler = _make_handler(web.FavoritesCollectionHandler, Mock())
+    handler._reason = "boom"
+    handler.write_error(500)
+    handler.set_header.assert_called_with("Content-Type", "application/json")
+    handler.finish.assert_called_once()
+    payload = json.loads(handler.finish.call_args.args[0])
+    assert payload == {"error": "boom"}


### PR DESCRIPTION
## Summary

Implements the favorites HTTP API discussed in #241 (option A — endpoints in
the existing HTTP frontend).

- Registers a Mopidy `http:app` so the routes mount at `/tidal/` alongside
  the rest of the Mopidy HTTP frontend.
- `POST /tidal/favorites/<kind>s` with body `{ "id": "<id>" }` adds a
  favorite. Returns 204.
- `DELETE /tidal/favorites/<kind>s/<id>` removes a favorite. Returns 204.
- `GET /tidal/favorites/<kind>s` lists current favorites as
  `[{ id, name, artist? }, ...]`.
- `<kind>` is one of `album`, `track`, `artist`, `playlist`.
- Authentication is implicit: the handlers reach the `TidalBackend` actor
  via `pykka.ActorRegistry` and reuse the `tidalapi.Session` it already
  holds, so clients don't re-implement OAuth.
- Returns 503 if the backend isn't logged in yet, 400 for invalid/empty body
  on POST.

Closes #241.

## Test plan

- [x] `uv run pytest tests/test_web.py tests/test_extension.py` — 31 passing
- [x] `uv run ruff format --check` — clean
- [x] `uv run ruff check` — clean
- [ ] Smoke-tested against a live Mopidy + mopidy-tidal: POST adds the album
      to the TIDAL library, GET lists it back, DELETE removes it, and the
      changes show up on the official client / web app on next refresh.
